### PR TITLE
switch to use default ssh key file name.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -7,7 +7,6 @@ Vagrant.configure("2") do |config|
 
   config.vm.provision :ansible_local,
                       playbook: "site.yml",
-                      config_file: "ansible.local.cfg",
                       inventory_path: "local",
                       limit: "all"
 end

--- a/ansible.local.cfg
+++ b/ansible.local.cfg
@@ -1,2 +1,0 @@
-[defaults]
-private_key_file = ~/.ssh/vagrant@localhost

--- a/vagrant/keygen-localhostself.sh
+++ b/vagrant/keygen-localhostself.sh
@@ -9,7 +9,7 @@ if [[ ! -d ${SSH_DIRECTORY_NAME} ]]; then
 	chmod 755 ${SSH_DIRECTORY_NAME}
 fi
 
-readonly PRIVATE_KEY_FILE="${SSH_DIRECTORY_NAME}/vagrant@localhost"
+readonly PRIVATE_KEY_FILE="${SSH_DIRECTORY_NAME}/id_ed25519"
 if [[ -e ${PRIVATE_KEY_FILE} ]]; then
 	echo ${PRIVATE_KEY_FILE} is exists. skip ssh-keygen.
 	exit 0


### PR DESCRIPTION
`vagrant@localhost` にしていたけれど、そもそもこの Vagrant マシンが頻繁に使い捨てられる環境なために鍵も頻繁に使い捨てられるので、区別可能 & 管理しやすい ような名前にする必要がなかった。

むしろ、デフォルトの名前にしておいたほうが、いろんなところでの設定を書かなくて住むので、便利。